### PR TITLE
Fix output file path for typst workflow

### DIFF
--- a/.github/workflows/typst.yaml
+++ b/.github/workflows/typst.yaml
@@ -15,7 +15,7 @@ jobs:
         id: tag
         run: |
           REF=${GITHUB_REF#refs/*/}
-          REF=${REF//\/-}
+          REF=${REF//\//-}
           echo "REF=$REF" >> $GITHUB_ENV
 
       - name: Typst


### PR DESCRIPTION
## Summary
- ensure branch names with slashes create valid PDF names

## Testing
- `apt-get update`
- `apt-get install -y ed`


------
https://chatgpt.com/codex/tasks/task_e_6843b7130e04832fb71a07af4c8ce63e