### PR TITLE
Update README with extra install methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,37 @@ You can download the latest compiled version (in PDF form) from:
 
 https://github.com/arran4/resume/releases
 
-Or build it yoursellf, you will need to install `typst` on your platform. Details on how to do that can be found here: 
+Or build it yourself. You will need to install `typst` on your platform. The easiest way is to follow the official instructions from [Typst](https://typst.app/docs/install/).
 
-https://typst.app/
+## Installing Typst
+
+1. Visit <https://typst.app/docs/install/> and follow the steps for your operating system.
+   - **macOS**: `brew install typst`
+   - **Linux**: use your distribution's package manager if available:
+     `apt install typst` (Debian/Ubuntu), `dnf install typst` (Fedora),
+     `pacman -S typst` (Arch). If no package exists, run the official
+     install script:
+
+     ```bash
+     curl --proto '=https' --tlsv1.2 -sSf https://typst.app/install.sh | sh
+     ```
+   - **Windows**: `winget install Typst.Typst` (via the Windows Package
+     Manager) or download the release from GitHub.
+2. Ensure the `typst` command is available in your `PATH`.
+
+## Building the resume
+
+Run the following commands from the repository root to generate the PDF and PNG outputs:
+
+```bash
+# Generate PDF
+TYPST_FONT_PATHS=./fonts typst compile resume.typ resume.pdf
+
+# Generate PNG for each page
+TYPST_FONT_PATHS=./fonts typst compile -f png resume.typ resume-page-{n}.png
+```
+
+This will create `resume.pdf` along with page images in the current directory.
 
 Feel free to fork and use for your own resume, however this is based off [Modern CV](https://typst.app/universe/package/modern-cv/) so you are best to start there, however feel free to copy the github actions code for compiling on tagging:
 


### PR DESCRIPTION
## Summary
- expand Linux installation instructions with distro packages and the install script
- clarify winget usage for Windows

## Testing
- `typst compile resume.typ resume.pdf`
- `typst compile -f png resume.typ resume-page-{n}.png`


------
https://chatgpt.com/codex/tasks/task_e_6843b78f62f4832fa9e79909253952ad