### PR TITLE
Update modern-cv to v0.8.0

### DIFF
--- a/resume.typ
+++ b/resume.typ
@@ -1,4 +1,4 @@
-#import "@preview/modern-cv:0.7.0": *
+#import "@preview/modern-cv:0.8.0": *
 
 #show: resume.with(
   author: (
@@ -14,6 +14,7 @@
         "Application & Integration Developer",
       )
   ),
+  profile-picture: none,
   date: datetime.today().display()
 )
 


### PR DESCRIPTION
## Summary
- use modern-cv 0.8.0 from Typst packages
- add `profile-picture` parameter as required by the update

## Testing
- `typst compile resume.typ out.pdf`

------
https://chatgpt.com/codex/tasks/task_e_6843b8d75e90832fb179dd6df4d89b73