### PR TITLE
Add Typst config

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,19 @@ You can download the latest compiled version (in PDF form) from:
 
 https://github.com/arran4/resume/releases
 
-Or build it yourself, you will need to install `typst` on your platform. Details on how to do that can be found here: 
+Or build it yourself, you will need to install `typst` on your platform. Details on how to do that can be found here:
 
 https://typst.app/
+
+Typst will automatically fetch packages listed in `typst.toml`. When compiling
+for the first time, ensure you have network access so the
+`modern-cv` package can be downloaded via Typst's package manager. Simply run
+
+```sh
+typst compile resume.typ
+```
+
+and Typst will retrieve the dependency before building the PDF.
 
 Feel free to fork and use for your own resume, however this is based off [Modern CV](https://typst.app/universe/package/modern-cv/) so you are best to start there, however feel free to copy the github actions code for compiling on tagging:
 

--- a/typst.toml
+++ b/typst.toml
@@ -1,0 +1,10 @@
+[package]
+name = "resume"
+version = "0.1.0"
+entrypoint = "resume.typ"
+
+[dependencies]
+modern-cv = "0.7.0"
+
+[fonts]
+paths = ["fonts"]


### PR DESCRIPTION
## Summary
- add `typst.toml` with modern-cv and font path
- document Typst package manager usage in README

## Testing
- `typst compile resume.typ`

------
https://chatgpt.com/codex/tasks/task_e_6843b8dbe2c4832f813b497209f95d09