### PR TITLE
Remove placeholder preview

### DIFF
--- a/.github/workflows/typst.yaml
+++ b/.github/workflows/typst.yaml
@@ -23,6 +23,23 @@ jobs:
         env:
           TYPST_FONT_PATHS: "./fonts/"
 
+      - name: Generate preview image
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ghostscript
+          mkdir -p assets
+          gs -sDEVICE=png16m -dNOPAUSE -dBATCH -dSAFER -r300 -dFirstPage=1 -dLastPage=1 \
+            -sOutputFile=assets/resume-preview.png Arran-Ubels-${{ env.REF }}.pdf
+
+      - name: Commit preview image
+        if: github.ref_type == 'tag'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add assets/resume-preview.png
+          git commit -m "Update preview image for ${{ env.REF }}" || echo "no changes"
+          git push origin HEAD:main
+
       - name: Typst
         uses: arran4/typst-action@patch-2
         with:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Arran Ubels Resume
 
+![Preview](assets/resume-preview.png)
+
 
 This is my attempt at a public resume / cv. An unabridged version, abridged versions might be discoverable in snapshots. If you have any suggestions, issues, and the like please raise an issue or a PR. Why else would I do this in git. 
 


### PR DESCRIPTION
## Summary
- remove the previously committed `assets/resume-preview.png`
- keep CI step that generates and commits the preview on release

## Testing
- `typst --version` *(fails: command not found)*
- `gs --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843b989a5a0832fbe11e791c39f37ca